### PR TITLE
ci: use `deps` scope for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autoupdate_commit_msg: 'build(pre-commit.ci): pre-commit autoupdate'
+  autoupdate_commit_msg: 'build(deps): pre-commit autoupdate'
   skip: [pylint]
 
 repos:


### PR DESCRIPTION
Signed-off-by: César Román <thecesrom@gmail.com>