### PR TITLE
fix(system): update type hint for `html` arg

### DIFF
--- a/src/system/net.py
+++ b/src/system/net.py
@@ -260,10 +260,10 @@ def openURL(url, useApplet=False):
 def sendEmail(
     smtp,  # type: String
     fromAddr,  # type: String
-    subject,  # type: String
-    body,  # type: String
-    html,  # type: String
-    to,  # type: List[String]
+    subject=None,  # type: Optional[String]
+    body=None,  # type: Optional[String]
+    html=False,  # type: Optional[bool]
+    to=None,  # type: Optional[List[String]]
     attachmentNames=None,  # type: Optional[List[object]]
     attachmentData=None,  # type: Optional[List[object]]
     timeout=300000,  # type: Optional[int]
@@ -288,10 +288,10 @@ def sendEmail(
             "mail.example.com:25". SSL can also be forced, like
             "mail.example.com:25:tls".
         fromAddr: An email address to have the email come from.
-        subject: The subject line for the email.
-        body: The body text of the email.
+        subject: The subject line for the email. Optional.
+        body: The body text of the email. Optional.
         html: A flag indicating whether or not to send the email as an
-            HTML email. Will auto-detect if omitted.
+            HTML email. Will auto-detect if omitted. Optional.
         to: A list of email addresses to send to.
         attachmentNames: A list of attachment names. Attachment names
             must have the correct extension for the file type or an


### PR DESCRIPTION
Fixes #16

# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format).

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When `system.net.sendEmail` is called and a `bool` is passed to `html`, PyCharm produces a warning with the following message:

>Expected type 'Union[str, unicode, None]', got 'bool' instead

Issue Number: #16

## What is the new behavior?
<!-- Please describe the new behavior. -->
The correct type hint is now used

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
