### PR TITLE
build(deps): freeze flake8 at 5.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,17 @@ on:
 
 jobs:
   test:
-    name: test ${{ matrix.python-version }}
+    name: ${{ matrix.tox-env }}
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7", "3.10"]
+        include:
+          - python-version: '2.7'
+            tox-env: install
+          - python-version: '3.10'
+            tox-env: lint
+          - python-version: '3.10'
+            tox-env: typecheck
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -21,11 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --requirement requirements.ci.txt
-    - name: Setup test suite
-      run: |
-        tox --notest
+        python -m pip install --upgrade pip tox
     - name: Run tests
       run: |
-        tox
+        tox -e ${{ matrix.tox-env }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/pydocstyle

--- a/tox.ini
+++ b/tox.ini
@@ -4,20 +4,20 @@ envlist =
     lint
     typecheck
 isolated_build = true
-skip_missing_interpreters = true
 
 [testenv:install]
 description = install package
 basepython = python2.7
 
 [testenv:lint]
-description = run static analysis and style check using pylint
+description = run static analysis and style check
 basepython = python3.10
 skip_install = true
 deps =
+    pre-commit
     pylint
 commands =
-    pylint src
+    pre-commit run --all-files --show-diff-on-failure
 
 [testenv:typecheck]
 description = run type check on code base
@@ -29,15 +29,10 @@ commands =
     mypy --config-file tox.ini src
 
 [flake8]
-ignore = E741, F401, F821
+ignore = E741, F821
 max-complexity = 10
 max-doc-length = 72
 max-line-length = 88
-
-[gh]
-python =
-    2.7 = install
-    3.10 = lint, typecheck
 
 [isort]
 extra_standard_library = typing


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`pre-commit.ci` updated `flake8` to version 6.0.0 in bc77f15 which depends on `puflakes` 3.0.0 which removes handling of python 2.x `# type:` comments.

This made us ignore error code `F401`, which may lower the quality of our code in the long term.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use `tox` to run our pre-commit hooks and disable `pre-commit.ci`, freeze `flake8` at version 5.0.4 and remove `F401` from the ignored list.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
