### PR TITLE
ci: use Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         include:
           - python-version: '2.7'
             tox-env: install
-          - python-version: '3.10'
+          - python-version: '3.11'
             tox-env: lint
-          - python-version: '3.10'
+          - python-version: '3.11'
             tox-env: typecheck
     steps:
     - uses: actions/checkout@v3

--- a/.pylintrc
+++ b/.pylintrc
@@ -53,7 +53,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.11
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -1,2 +1,0 @@
-tox; python_version=='2.7'
-tox-gh; python_version>='3.10'

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython = python2.7
 
 [testenv:lint]
 description = run static analysis and style check
-basepython = python3.10
+basepython = python3.11
 skip_install = true
 deps =
     pre-commit
@@ -21,7 +21,7 @@ commands =
 
 [testenv:typecheck]
 description = run type check on code base
-basepython = python3.10
+basepython = python3.11
 skip_install = true
 deps =
     mypy[python2]==0.971


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We use Python 3.10 for running linting and static checks.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will switch to Python 3.11.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

delete unused requirements.ci.txt file.