### PR TITLE
ci: use thecesrom/workflows v1.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,16 @@ jobs:
 
   tox:
     needs: set-defaults
-    uses: thecesrom/workflows/.github/workflows/tox.yml@v1.1.1
+    uses: thecesrom/workflows/.github/workflows/tox.yml@v1.2.0
     with:
       image: ${{ needs.set-defaults.outputs.image }}
 
   pre-commit:
     needs: [set-defaults, tox]
-    uses: thecesrom/workflows/.github/workflows/pre-commit.yml@v1.1.1
+    uses: thecesrom/workflows/.github/workflows/pre-commit.yml@v1.2.0
     with:
       image: ${{ needs.set-defaults.outputs.image }}
+      skip-hooks: pylint
 
   pylint:
     needs: [set-defaults, tox, pre-commit]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   main:
-    uses: thecesrom/workflows/.github/workflows/pypi-upload.yml@v1.1.1
+    uses: thecesrom/workflows/.github/workflows/pypi-upload.yml@v1.2.0
     with:
       image: ubuntu-20.04
       python-version: "2.7"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
     hooks:
       - id: pydocstyle
         exclude: ^(src/com/|src/java/|src/javax/|src/org/)
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.41.0
     hooks:


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [commit message format](https://github.com/ignition-api/.github/blob/main/CONTRIBUTING.md#commit-message-format)
- [x] All applicable pre-commit hooks have passed when running `pre-commit run --all-files`
- [x] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using thecesrom/workflows@v1.1.0 and not running pylint as a pre-commit hook

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will use thecesrom/workflows@v1.2.0 and reestablish pylint as a pre-commit hook

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
